### PR TITLE
Add optional `serde` feature for `serde` support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["algorithms", "data-structures"]
 
 [dependencies]
 rand = "0.8"
-serde = { version = "1.0.145", optional = true , features = ["derive"] }
+serde = { version = "1.0", optional = true , features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"
-serde = { version = "1.0.145", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ categories = ["algorithms", "data-structures"]
 
 [dependencies]
 rand = "0.8"
+serde = { version = "1.0.145", optional = true , features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ categories = ["algorithms", "data-structures"]
 [dependencies]
 rand = "0.8"
 serde = { version = "1.0.145", optional = true , features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"
+serde = { version = "1.0.145", features = ["derive"] }

--- a/src/interval_tree.rs
+++ b/src/interval_tree.rs
@@ -951,12 +951,12 @@ mod tests {
 		    ],
 		    "left": null,
 		    "right": null,
-		    "value": {"Excluded": 4},
+		    "value": {"Excluded": 3},
 		},
 		"right": null,
 		"value": {"Included": 4},
 	    },
-	    "size": 1,
+	    "size": 2,
 	});
 	assert_eq!(expected_value, deserialized_tree);
     }
@@ -987,12 +987,12 @@ mod tests {
 		    ],
 		    "left": null,
 		    "right": null,
-		    "value": {"Excluded": 4},
+		    "value": {"Excluded": 3},
 		},
 		"right": null,
 		"value": {"Included": 4},
 	    },
-	    "size": 1,
+	    "size": 2,
 	});
 	let serialized_value = value.to_string();
 	let deserialized_tree = from_str(&serialized_value).unwrap();

--- a/src/interval_tree.rs
+++ b/src/interval_tree.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::ops::Bound;
 use std::ops::Bound::*;
 use std::ops::RangeBounds;
-#[cfg(feature="serde")]
+#[cfg(any(feature="serde", test))]
 use serde::{Serialize, Deserialize};
 
 /// The interval tree storing all the underlying intervals.
@@ -34,7 +34,7 @@ use serde::{Serialize, Deserialize};
 /// let interval_tree = IntervalTree::from(ranges);
 /// assert_eq!(interval_tree.len(), 2);
 /// ```
-#[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
+#[cfg_attr(any(feature="serde", test), derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct IntervalTree<K> {
     root: Option<Box<Node<K>>>,
@@ -907,7 +907,79 @@ impl<'a, K> Iterator for IntervalTreeIter<'a, K> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::{Value, from_str, json, to_string};
+    
+    #[test]
+    fn serialize_deserialize_identity() {
+	let mut tree = IntervalTree::default();
+	let serialized_empty_tree = to_string(&tree).unwrap();
+	let deserialized_empty_tree = from_str(&serialized_empty_tree).unwrap();
+	assert_eq!(tree, deserialized_empty_tree);
 
+	tree.insert((Included(1), Excluded(3)));
+	let serialized_tree = to_string(&tree).unwrap();
+	let deserialized_tree = from_str(&serialized_tree).unwrap();
+	assert_eq!(tree, deserialized_tree);
+    }
+
+    #[test]
+    fn serialize() {
+	let mut tree = IntervalTree::default();
+	let serialized_empty_tree = to_string(&tree).unwrap();
+	let deserialized_empty_value: Value = from_str(&serialized_empty_tree).unwrap();
+	let expected_empty_value = json!({
+	    "root": null,
+	    "size": 0,
+	});
+	assert_eq!(expected_empty_value, deserialized_empty_value);
+
+	tree.insert((Included(1), Excluded(3)));
+	let serialized_tree = to_string(&tree).unwrap();
+	let deserialized_tree: Value = from_str(&serialized_tree).unwrap();
+	let expected_value = json!({
+	    "root": {
+		"key": [
+		    {"Included": 1},
+		    {"Excluded": 3},
+		],
+		"left": null,
+		"right": null,
+		"value": {"Excluded": 3},
+	    },
+	    "size": 1,
+	});
+	assert_eq!(expected_value, deserialized_tree);
+    }
+
+    #[test]
+    fn deserialize() {
+	let mut expected_tree = IntervalTree::default();
+	let empty_value = json!({
+	    "root": null,
+	    "size": 0,
+	});
+	let serialized_empty_value = empty_value.to_string();
+	let deserialized_empty_tree = from_str(&serialized_empty_value).unwrap();
+	assert_eq!(expected_tree, deserialized_empty_tree);
+
+	expected_tree.insert((Included(1), Excluded(3)));
+	let value = json!({
+	    "root": {
+		"key": [
+		    {"Included": 1},
+		    {"Excluded": 3},
+		],
+		"left": null,
+		"right": null,
+		"value": {"Excluded": 3},
+	    },
+	    "size": 1,
+	});
+	let serialized_value = value.to_string();
+	let deserialized_tree = from_str(&serialized_value).unwrap();
+	assert_eq!(expected_tree, deserialized_tree);
+    }
+    
     #[test]
     fn it_inserts_root() {
         let mut tree = IntervalTree::default();

--- a/src/interval_tree.rs
+++ b/src/interval_tree.rs
@@ -933,18 +933,28 @@ mod tests {
 	});
 	assert_eq!(expected_empty_value, deserialized_empty_value);
 
+	tree.insert((Included(2), Included(4)));
 	tree.insert((Included(1), Excluded(3)));
+	
 	let serialized_tree = to_string(&tree).unwrap();
 	let deserialized_tree: Value = from_str(&serialized_tree).unwrap();
 	let expected_value = json!({
 	    "root": {
 		"key": [
-		    {"Included": 1},
-		    {"Excluded": 3},
+		    {"Included": 2},
+		    {"Included": 4},
 		],
-		"left": null,
+		"left": {
+		    "key": [
+			{"Included": 1},
+			{"Excluded": 3},
+		    ],
+		    "left": null,
+		    "right": null,
+		    "value": {"Excluded": 4},
+		},
 		"right": null,
-		"value": {"Excluded": 3},
+		"value": {"Included": 4},
 	    },
 	    "size": 1,
 	});
@@ -962,16 +972,25 @@ mod tests {
 	let deserialized_empty_tree = from_str(&serialized_empty_value).unwrap();
 	assert_eq!(expected_tree, deserialized_empty_tree);
 
+	expected_tree.insert((Included(2), Included(4)));
 	expected_tree.insert((Included(1), Excluded(3)));
 	let value = json!({
 	    "root": {
 		"key": [
-		    {"Included": 1},
-		    {"Excluded": 3},
+		    {"Included": 2},
+		    {"Included": 4},
 		],
-		"left": null,
+		"left": {
+		    "key": [
+			{"Included": 1},
+			{"Excluded": 3},
+		    ],
+		    "left": null,
+		    "right": null,
+		    "value": {"Excluded": 4},
+		},
 		"right": null,
-		"value": {"Excluded": 3},
+		"value": {"Included": 4},
 	    },
 	    "size": 1,
 	});

--- a/src/interval_tree.rs
+++ b/src/interval_tree.rs
@@ -8,6 +8,8 @@ use std::mem;
 use std::ops::Bound;
 use std::ops::Bound::*;
 use std::ops::RangeBounds;
+#[cfg(feature="serde")]
+use serde::{Serialize, Deserialize};
 
 /// The interval tree storing all the underlying intervals.
 ///
@@ -32,6 +34,7 @@ use std::ops::RangeBounds;
 /// let interval_tree = IntervalTree::from(ranges);
 /// assert_eq!(interval_tree.len(), 2);
 /// ```
+#[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct IntervalTree<K> {
     root: Option<Box<Node<K>>>,

--- a/src/node.rs
+++ b/src/node.rs
@@ -6,106 +6,6 @@ use serde::{Serialize, Deserialize};
 
 pub(crate) type Range<K> = (Bound<K>, Bound<K>);
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::{Value, from_str, json, to_string};
-    
-    #[test]
-    fn serialize_deserialize_identity() {
-	let leaf = Node::new((Included(1), Excluded(3)));
-	let serialized_leaf = to_string(&leaf).unwrap();
-	let deserialized_leaf = from_str(&serialized_leaf).unwrap();
-	assert_eq!(leaf, deserialized_leaf);
-
-	let mut node = Node::new((Included(2), Included(4)));
-	node.left = Some(Box::new(leaf));
-	let serialized_node = to_string(&node).unwrap();
-	let deserialized_node = from_str(&serialized_node).unwrap();
-	assert_eq!(node, deserialized_node);
-    }
-
-    #[test]
-    fn serialize() {
-	let leaf = Node::new((Included(1), Excluded(3)));
-	let serialized_leaf = to_string(&leaf).unwrap();
-	let deserialized_value: Value = from_str(&serialized_leaf).unwrap();
-	let expected_value = json!({
-	    "key": [
-		{"Included": 1},
-		{"Excluded": 3},
-	    ],
-	    "left": null,
-	    "right": null,
-	    "value": {"Excluded": 3}
-	});
-	assert_eq!(expected_value, deserialized_value);
-
-	let mut node = Node::new((Included(2), Included(4)));
-	node.left = Some(Box::new(leaf));
-	let serialized_node = to_string(&node).unwrap();
-	let deserialized_value: Value = from_str(&serialized_node).unwrap();
-	let expected_value = json!({
-	    "key": [
-		{"Included": 2},
-		{"Included": 4},
-	    ],
-	    "left": {
-		"key": [
-		    {"Included": 1},
-		    {"Excluded": 3},
-		],
-		"left": null,
-		"right": null,
-		"value": {"Excluded": 3},
-	    },
-	    "right": null,
-	    "value": {"Included": 4},
-	});
-	assert_eq!(expected_value, deserialized_value);
-    }
-    
-    #[test]
-    fn deserialize() {
-	let expected_leaf = Node::new((Included(1), Excluded(3)));
-	let value = json!({
-	    "key": [
-		{"Included": 1},
-		{"Excluded": 3},
-	    ],
-	    "left": null,
-	    "right": null,
-	    "value": {"Excluded": 3},
-	});
-	let serialized_value = value.to_string();
-	let deserialized_leaf = from_str(&serialized_value).unwrap();
-	assert_eq!(expected_leaf, deserialized_leaf);
-
-	let mut expected_node = Node::new((Included(2), Included(4)));
-	expected_node.left = Some(Box::new(expected_leaf));
-	let value = json!({
-	    "key": [
-		{"Included": 2},
-		{"Included": 4},
-	    ],
-	    "left": {
-		"key": [
-		    {"Included": 1},
-		    {"Excluded": 3},
-		],
-		"left": null,
-		"right": null,
-		"value": {"Excluded": 3},
-	    },
-	    "right": null,
-	    "value": {"Included": 4},
-	});
-	let serialized_value = value.to_string();
-	let deserialized_node = from_str(&serialized_value).unwrap();
-	assert_eq!(expected_node, deserialized_node);
-    }
-}
-
 #[cfg_attr(any(feature="serde", test), derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Node<K> {
@@ -212,5 +112,105 @@ impl<K> Node<K> {
                 }
             }
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, from_str, json, to_string};
+    
+    #[test]
+    fn serialize_deserialize_identity() {
+	let leaf = Node::new((Included(1), Excluded(3)));
+	let serialized_leaf = to_string(&leaf).unwrap();
+	let deserialized_leaf = from_str(&serialized_leaf).unwrap();
+	assert_eq!(leaf, deserialized_leaf);
+
+	let mut node = Node::new((Included(2), Included(4)));
+	node.left = Some(Box::new(leaf));
+	let serialized_node = to_string(&node).unwrap();
+	let deserialized_node = from_str(&serialized_node).unwrap();
+	assert_eq!(node, deserialized_node);
+    }
+
+    #[test]
+    fn serialize() {
+	let leaf = Node::new((Included(1), Excluded(3)));
+	let serialized_leaf = to_string(&leaf).unwrap();
+	let deserialized_value: Value = from_str(&serialized_leaf).unwrap();
+	let expected_value = json!({
+	    "key": [
+		{"Included": 1},
+		{"Excluded": 3},
+	    ],
+	    "left": null,
+	    "right": null,
+	    "value": {"Excluded": 3}
+	});
+	assert_eq!(expected_value, deserialized_value);
+
+	let mut node = Node::new((Included(2), Included(4)));
+	node.left = Some(Box::new(leaf));
+	let serialized_node = to_string(&node).unwrap();
+	let deserialized_value: Value = from_str(&serialized_node).unwrap();
+	let expected_value = json!({
+	    "key": [
+		{"Included": 2},
+		{"Included": 4},
+	    ],
+	    "left": {
+		"key": [
+		    {"Included": 1},
+		    {"Excluded": 3},
+		],
+		"left": null,
+		"right": null,
+		"value": {"Excluded": 3},
+	    },
+	    "right": null,
+	    "value": {"Included": 4},
+	});
+	assert_eq!(expected_value, deserialized_value);
+    }
+    
+    #[test]
+    fn deserialize() {
+	let expected_leaf = Node::new((Included(1), Excluded(3)));
+	let value = json!({
+	    "key": [
+		{"Included": 1},
+		{"Excluded": 3},
+	    ],
+	    "left": null,
+	    "right": null,
+	    "value": {"Excluded": 3},
+	});
+	let serialized_value = value.to_string();
+	let deserialized_leaf = from_str(&serialized_value).unwrap();
+	assert_eq!(expected_leaf, deserialized_leaf);
+
+	let mut expected_node = Node::new((Included(2), Included(4)));
+	expected_node.left = Some(Box::new(expected_leaf));
+	let value = json!({
+	    "key": [
+		{"Included": 2},
+		{"Included": 4},
+	    ],
+	    "left": {
+		"key": [
+		    {"Included": 1},
+		    {"Excluded": 3},
+		],
+		"left": null,
+		"right": null,
+		"value": {"Excluded": 3},
+	    },
+	    "right": null,
+	    "value": {"Included": 4},
+	});
+	let serialized_value = value.to_string();
+	let deserialized_node = from_str(&serialized_value).unwrap();
+	assert_eq!(expected_node, deserialized_node);
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,9 +1,12 @@
 use std::fmt;
 use std::ops::Bound;
 use std::ops::Bound::*;
+#[cfg(feature="serde")]
+use serde::{Serialize, Deserialize};
 
 pub(crate) type Range<K> = (Bound<K>, Bound<K>);
 
+#[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Node<K> {
     pub key: Range<K>,

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,12 +1,112 @@
 use std::fmt;
 use std::ops::Bound;
 use std::ops::Bound::*;
-#[cfg(feature="serde")]
+#[cfg(any(feature="serde", test))]
 use serde::{Serialize, Deserialize};
 
 pub(crate) type Range<K> = (Bound<K>, Bound<K>);
 
-#[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, from_str, json, to_string};
+    
+    #[test]
+    fn serialize_deserialize_identity() {
+	let leaf = Node::new((Included(1), Excluded(3)));
+	let serialized_leaf = to_string(&leaf).unwrap();
+	let deserialized_leaf = from_str(&serialized_leaf).unwrap();
+	assert_eq!(leaf, deserialized_leaf);
+
+	let mut node = Node::new((Included(2), Included(4)));
+	node.left = Some(Box::new(leaf));
+	let serialized_node = to_string(&node).unwrap();
+	let deserialized_node = from_str(&serialized_node).unwrap();
+	assert_eq!(node, deserialized_node);
+    }
+
+    #[test]
+    fn serialize() {
+	let leaf = Node::new((Included(1), Excluded(3)));
+	let serialized_leaf = to_string(&leaf).unwrap();
+	let deserialized_value: Value = from_str(&serialized_leaf).unwrap();
+	let expected_value = json!({
+	    "key": [
+		{"Included": 1},
+		{"Excluded": 3},
+	    ],
+	    "left": null,
+	    "right": null,
+	    "value": {"Excluded": 3}
+	});
+	assert_eq!(expected_value, deserialized_value);
+
+	let mut node = Node::new((Included(2), Included(4)));
+	node.left = Some(Box::new(leaf));
+	let serialized_node = to_string(&node).unwrap();
+	let deserialized_value: Value = from_str(&serialized_node).unwrap();
+	let expected_value = json!({
+	    "key": [
+		{"Included": 2},
+		{"Included": 4},
+	    ],
+	    "left": {
+		"key": [
+		    {"Included": 1},
+		    {"Excluded": 3},
+		],
+		"left": null,
+		"right": null,
+		"value": {"Excluded": 3},
+	    },
+	    "right": null,
+	    "value": {"Included": 4},
+	});
+	assert_eq!(expected_value, deserialized_value);
+    }
+    
+    #[test]
+    fn deserialize() {
+	let expected_leaf = Node::new((Included(1), Excluded(3)));
+	let value = json!({
+	    "key": [
+		{"Included": 1},
+		{"Excluded": 3},
+	    ],
+	    "left": null,
+	    "right": null,
+	    "value": {"Excluded": 3},
+	});
+	let serialized_value = value.to_string();
+	let deserialized_leaf = from_str(&serialized_value).unwrap();
+	assert_eq!(expected_leaf, deserialized_leaf);
+
+	let mut expected_node = Node::new((Included(2), Included(4)));
+	expected_node.left = Some(Box::new(expected_leaf));
+	let value = json!({
+	    "key": [
+		{"Included": 2},
+		{"Included": 4},
+	    ],
+	    "left": {
+		"key": [
+		    {"Included": 1},
+		    {"Excluded": 3},
+		],
+		"left": null,
+		"right": null,
+		"value": {"Excluded": 3},
+	    },
+	    "right": null,
+	    "value": {"Included": 4},
+	});
+	let serialized_value = value.to_string();
+	let deserialized_node = from_str(&serialized_value).unwrap();
+	assert_eq!(expected_node, deserialized_node);
+    }
+}
+
+#[cfg_attr(any(feature="serde", test), derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Node<K> {
     pub key: Range<K>,


### PR DESCRIPTION
This commit add a feature "serde" (disabled by default) which pulls in the optional dependency serde and implements `Serialize` and `Deserialize` for `IntervalTree`.